### PR TITLE
[Autodelivery] update Automerge on non-CI events from DanySK/centralized-automated-deployer@376b72e

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,24 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - reopened
+      - unlocked
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "DanySK/yaagha@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_TOKEN }}"
+          MERGE_FORKS: "false"
+          MERGE_LABELS: "version-upgrade"
+          BLOCK_LABELS: "blocked, wontfix, invalid"
+          MERGE_METHOD: "rebase"
+          CLOSE_ON_CONFLICT: "true"
+          DELETE_BRANCH_ON_CLOSE: "true"
+          GIT_USER_NAME: "Danilo Pianini"
+          GIT_USER_EMAIL: "danilo.pianini@gmail.com"


### PR DESCRIPTION
This pull request has been created automatically by [Autodelivery](https://github.com/DanySK/autodelivery), at your service.

To the best of this bot's understanding, it updates a content described as

> Automerge on non-CI events

and this PR updates it to the same version of DanySK/centralized-automated-deployer@376b72e.

Hope it helps!
